### PR TITLE
Add Meilisearch search endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ uvicorn==0.34.0
 uvloop==0.21.0
 watchfiles==1.0.4
 websockets==15.0.1
+meilisearch==0.36.0

--- a/router.py
+++ b/router.py
@@ -6,7 +6,6 @@ from fastapi.security import OAuth2PasswordRequestForm
 from starlette import status
 
 import service
-from util import get_meilisearch
 from auth import authenticate_user, ACCESS_TOKEN_EXPIRE_MINUTES, create_access_token, get_current_active_user, \
     verify_password, get_password_hash
 from database import SessionDep, get_session
@@ -55,7 +54,7 @@ async def search_devices(
         )],
     session: Annotated[SessionDep, Depends(get_session)]
 ):
-    results = await get_meilisearch(q)
+    results = await service.search_devices(q)
     return [DevicePublic(**res) for res in results]
 
 @api_router.get("/user/devices/{device_id}",response_model=DevicePublic)

--- a/router.py
+++ b/router.py
@@ -6,6 +6,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from starlette import status
 
 import service
+from util import get_meilisearch
 from auth import authenticate_user, ACCESS_TOKEN_EXPIRE_MINUTES, create_access_token, get_current_active_user, \
     verify_password, get_password_hash
 from database import SessionDep, get_session
@@ -42,6 +43,20 @@ async def get_device(
     session: Annotated[SessionDep, Depends(get_session)]
 ):
     return find_all_devices(session)
+
+
+@api_router.get("/user/devices/search", response_model=list[DevicePublic])
+async def search_devices(
+    q: str,
+    current_user: Annotated[
+        User,
+        Depends(
+            get_current_active_user
+        )],
+    session: Annotated[SessionDep, Depends(get_session)]
+):
+    results = await get_meilisearch(q)
+    return [DevicePublic(**res) for res in results]
 
 @api_router.get("/user/devices/{device_id}",response_model=DevicePublic)
 async def get_device(

--- a/service.py
+++ b/service.py
@@ -2,6 +2,12 @@ from datetime import datetime
 from tkinter.tix import Select
 from typing import Sequence, Type
 
+from util import (
+    add_document_to_meilisearch,
+    update_document_in_meilisearch,
+    delete_document_from_meilisearch,
+)
+
 from sqlmodel import Session, select
 
 from models import Device, User, DevicePublic, DeviceCreate
@@ -32,12 +38,17 @@ def update_device_by_id(device_id: int, device: DevicePublic, session: Session) 
     session.add(db_device)
     session.commit()
     session.refresh(db_device)
+
+    update_document_in_meilisearch(db_device.dict())
+
     return db_device
 
 def delete_device_by_id(device_id: int, session: Session) -> None:
     device = session.get(Device, device_id)
     session.delete(device)
     session.commit()
+
+    delete_document_from_meilisearch(device_id)
     return None
 
 def create_device(device: DeviceCreate, session: Session) -> Device:
@@ -46,6 +57,9 @@ def create_device(device: DeviceCreate, session: Session) -> Device:
     session.add(db_device)
     session.commit()
     session.refresh(db_device)
+
+    add_document_to_meilisearch(db_device.dict())
+
     return db_device
 
 def update_user(user: User, session: Session) -> Type[User] | None:

--- a/service.py
+++ b/service.py
@@ -1,11 +1,12 @@
 from datetime import datetime
-from tkinter.tix import Select
+from sqlalchemy.sql import Select
 from typing import Sequence, Type
 
 from util import (
     add_document_to_meilisearch,
     update_document_in_meilisearch,
     delete_document_from_meilisearch,
+    get_meilisearch,
 )
 
 from sqlmodel import Session, select
@@ -19,8 +20,12 @@ def find_all_devices(session: Session) -> Sequence[Device]:
 def load_test_message() -> dict[str, str]:
     return {"message": "Hello World"}
 
+async def search_devices(term: str) -> list[dict]:
+    """Search devices from Meilisearch by term."""
+    return await get_meilisearch(term)
+
 def find_user_by_email(email: str, session: Session) -> User | None:
-    statement: Select= select(User).where(User.email == email)
+    statement: Select = select(User).where(User.email == email)
     return session.exec(statement).first()
 
 def find_by_device_id(device_id: int, session: Session) -> Device | None:

--- a/util.py
+++ b/util.py
@@ -22,8 +22,25 @@ async def get_meilisearch(term: str) -> list[dict]:
     return documents_list
 
 def add_document_to_meilisearch(document: dict):
-    # Create a new index
+    """Add a single document to the devices index."""
     index = client.index('devices')
-
-    # Add a document to the index
     index.add_documents([document])
+
+
+def update_document_in_meilisearch(document: dict):
+    """Update a document in the devices index."""
+    index = client.index('devices')
+    index.add_documents([document])
+
+
+def delete_document_from_meilisearch(document_id: int):
+    """Delete a document from the devices index."""
+    index = client.index('devices')
+    index.delete_document(str(document_id))
+
+
+def index_bulk_devices(documents: list[dict]):
+    """Add multiple documents to the devices index."""
+    index = client.index('devices')
+    index.add_documents(documents)
+


### PR DESCRIPTION
## Summary
- add meilisearch python client requirement
- extend util helpers for managing search index
- update device service operations to keep index in sync
- provide `/user/devices/search` endpoint for searching

## Testing
- `pytest -q`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685a8e55601083319b575b5d82057596